### PR TITLE
Add cflinuxfs5 support for Go buildpack

### DIFF
--- a/jobs/go-buildpack/spec
+++ b/jobs/go-buildpack/spec
@@ -3,6 +3,7 @@ name: go-buildpack
 templates: {}
 
 packages:
+- go-buildpack-cflinuxfs5
 - go-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/go-buildpack-cflinuxfs5/packaging
+++ b/packages/go-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,2 @@
+    set -e -x
+    cp go-buildpack/go?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/go-buildpack-cflinuxfs5/spec
+++ b/packages/go-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: go-buildpack-cflinuxfs5
+files:
+- go-buildpack/go?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the go-buildpack BOSH release, following the same pattern used for cflinuxfs4 addition in commit f5d5bef.

Changes:
- Create packages/go-buildpack-cflinuxfs5/spec - package specification
- Create packages/go-buildpack-cflinuxfs5/packaging - build script
- Update jobs/go-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy Go applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release (v1.10.47+) will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.